### PR TITLE
Bundle MariaDB in MSI packaging

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Build project
         run: mvn clean package
 
+      - name: Copy runtime dependencies
+        shell: pwsh
+        run: |
+          mvn dependency:copy-dependencies -DincludeScope=runtime -Dmdep.useBaseVersion=true
+          Copy-Item target/dependency/*.jar target/
+
       - name: Download and extract JavaFX JMODs
         run: |
           curl -L -o javafx-jmods.zip https://download2.gluonhq.com/openjfx/20.0.2/openjfx-20.0.2_windows-x64_bin-jmods.zip
@@ -47,6 +53,14 @@ jobs:
       - name: Verificar contenido del JAR
         run: jar tf target/aluFx-1.0-SNAPSHOT.jar
         shell: cmd
+
+      - name: Descargar y extraer MariaDB
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://archive.mariadb.org/mariadb-10.11.6/winx64-packages/mariadb-10.11.6-winx64.zip -OutFile mariadb.zip
+          Expand-Archive mariadb.zip -DestinationPath mariadb-temp
+          Move-Item -Path 'mariadb-temp\mariadb-10.11.6-winx64\*' -Destination 'mariadb' -Force
+          Remove-Item -Recurse -Force mariadb-temp, mariadb.zip
 
       - name: Package MSI with jpackage
         run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ Descargar https://gluonhq.com/products/javafx/ version 20.0.0.1, descomprimir en
 
 Ejecutar el jar que esta en out como ´ java --module-path /carpeta/javafx-sdk-20.0.1/lib --add-module=javafx.controls,javafx.fxml -jar aluFX.jar ´
 
-Previa instalación de mysql con la configuración en duro
+El flujo de trabajo de GitHub Actions descarga MariaDB 10.11.6 y la incluye de forma portable en el instalador, por lo que no se requiere una instalación previa de MySQL. El paquete también añade el script `scripts/start-mariadb.bat` que inicializa el servidor al ejecutar la aplicación.
 
 

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -1,2 +1,0 @@
-cd mariadb\bin
-mysqld --defaults-file=../my.ini --initialize-insecure --console

--- a/scripts/start-mariadb.bat
+++ b/scripts/start-mariadb.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Launch bundled MariaDB using the provided configuration
+cd /d "%~dp0..\mariadb\bin"
+mysqld --defaults-file=..\my.ini --console
+

--- a/src/main/java/com/meztli/alufx/MariaDBLauncher.java
+++ b/src/main/java/com/meztli/alufx/MariaDBLauncher.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 public class MariaDBLauncher {
     public static void launch() {
         try {
-            File batFile = new File("scripts/setup.bat");
+            File batFile = new File("scripts/start-mariadb.bat");
             if (!batFile.exists()) {
                 System.err.println("❌ Script start-mariadb.bat no encontrado");
                 return;


### PR DESCRIPTION
## Summary
- download MariaDB during workflow and include its start script
- copy runtime dependencies so packaged app can find Jakarta Persistence
- note in README that the installer includes start-mariadb.bat

## Testing
- `mvn -q -ntp package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688af7e8435c8323a8589da80fcdc922